### PR TITLE
Adds style extension points to let users adjust the video element to their liking.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,6 @@
     "iron-icons": "PolymerElements/iron-icons#^1.1.3",
     "paper-icon-button": "PolymerElements/paper-icon-button#^1.1.1",
     "paper-slider": "PolymerElements/paper-slider#^1.0.10",
-    "paper-styles": "PolymerElements/paper-styles#^1.1.4"
+    "paper-styles": "^1.1.4"
   }
 }

--- a/paper-video.html
+++ b/paper-video.html
@@ -27,9 +27,7 @@
 			--paper-video-controls-background: white;
 			--paper-video-controls-color: #595959;
 			--paper-video-slider-color: var(--primary-color);
-		}
-		:host paper-ripple {
-			color: --paper-video-controls-color;
+      @apply(--paper-video);
 		}
 		:host paper-slider {
 			--paper-slider-active-color: var(--paper-video-slider-color);
@@ -39,6 +37,7 @@
 			position: relative;
 			display: inline-block;
       outline: none;
+      @apply(--paper-video-container);
 		}
 		:host #videoControls {
 			position: absolute;
@@ -51,9 +50,10 @@
 			padding: 15px;
 			align-items: center;
       transition: 0.1s;
+      @apply(--paper-video-controls);
 		}
 		:host paper-ripple {
-			color: white;
+			color: var(--paper-video-ripple-color, var(--paper-video-controls-color));
 			opacity: 0.4;
 		}
 		:host #durationSlider {
@@ -71,6 +71,7 @@
 		}
 		:host video {
 			background-color: black;
+      @apply(--paper-video-video);
 		}
     :host(.controls-hidden)) {
       cursor: none;

--- a/paper-video.html
+++ b/paper-video.html
@@ -18,6 +18,7 @@
 <link rel="import" href="../paper-material/paper-material.html">
 <link rel="import" href="../paper-slider/paper-slider.html">
 <link rel="import" href="../paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../paper-styles/typography.html">
 <link rel="import" href="../iron-icons/iron-icons.html">
 <link rel="import" href="../iron-icons/av-icons.html">
 <dom-module id="paper-video">
@@ -62,8 +63,7 @@
 			max-width: 120px;
 		}
 		:host .video-time {
-		    font-family: 'Roboto';
-    		font-size: 12px;
+      @apply(--paper-font-caption);
 		}
 		:host #container:-webkit-full-screen, :host #container:-webkit-full-screen video {
 		  width: 100vw;

--- a/paper-video.html
+++ b/paper-video.html
@@ -39,6 +39,9 @@
       outline: none;
       @apply(--paper-video-container);
 		}
+    :host .video {
+      @apply(--paper-video-wrapper);
+    }
 		:host #videoControls {
 			position: absolute;
 			bottom: 4px;

--- a/paper-video.html
+++ b/paper-video.html
@@ -76,7 +76,7 @@
 			background-color: black;
       @apply(--paper-video-video);
 		}
-    :host(.controls-hidden)) {
+    :host(.controls-hidden) {
       cursor: none;
     }
     :host(.controls-hidden:not([controls])) {
@@ -116,7 +116,8 @@
 				controls: {
 					type: Boolean,
 					value: false,
-					notify: true
+					notify: true,
+          reflectToAttribute: true
 				},
 				autoplay: {
 					type: Boolean,


### PR DESCRIPTION
The following mixins are added:
- `--paper-video` to style `:host`
- `--paper-video-container` to style `#container`
- `--paper-video-wrapper` to style the div that wraps the video itself
- `--paper-video-video` to style the video element
- `--paper-video-controls` to style the controls
- Variable `--paper-video-ripple-color` added, which defaults to `--paper-video-controls-color`

The timecode label was changed to use `--paper-font-caption` so that apps can just override that one and set the global paper element caption style.

The `controls` property has been changed to reflect to property so users who dynamically create the paper-video and set `v.controls = true` get the correct autohiding behaviour.
