### PR TITLE
Bind to width and height attribute instead of property on <video>

### DIFF
--- a/paper-video.html
+++ b/paper-video.html
@@ -107,7 +107,7 @@
         <div id="container" class="container" tabindex$=[[tabindex]]>
             <paper-ripple></paper-ripple>
             <div class="video">
-                <video on-tap="_handleTap" muted="{{muted}}" width="{{width}}" poster="{{poster}}" preload="{{preload}}" height="{{height}}" id="paperVideo" src="{{src}}" autoplay="{{autoplay}}" loop="{{loop}}"></video>
+                <video on-tap="_handleTap" muted="{{muted}}" width$="{{width}}" poster="{{poster}}" preload="{{preload}}" height$="{{height}}" id="paperVideo" src="{{src}}" autoplay="{{autoplay}}" loop="{{loop}}"></video>
             </div>
             <paper-material elevation="1" hidden$="{{!controls}}" id="videoControls">
                 <paper-icon-button id="playPauseIcon" on-tap="toggle" icon="av:play-arrow"></paper-icon-button>


### PR DESCRIPTION
Fixes #11 by binding the width and height to the attributes instead of the properties on the `<video>` element. It looks like expected behaviour by Polymer: 
https://www.polymer-project.org/1.0/docs/devguide/data-binding#anatomy-of-a-data-binding