### PR TITLE
Constrained the ripple effect to only get triggered when tapping on the actual video

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-##&lt;paper-video&gt;
+## &lt;paper-video&gt;
 
 `paper-video` is a material design styled video player. It contains a video placed in the top and
 controls in the bottom. User can fully customize the controllers and the events.
 
 [Live Example](http://spacee.xyz/polymer-components/paper-video/demo.html)
 
-##Installing with Bower
+### Installing with Bower
 
 To install the component with the Bower, just run: 
 
@@ -31,7 +31,7 @@ The following custom properties and mixins are available for styling:
 | `--paper-video-ripple-color` | The ripple color for all taps on the container | `--paper-video-controls-color` |
 | `--paper-video-slider-color` | The timeline and volume sliders color | `#3367D6` |
 
-###&lt;paper-video&gt; - Properties
+### Properties
 
 The following properties are available:
 

--- a/paper-video.html
+++ b/paper-video.html
@@ -105,8 +105,8 @@
     </style>
     <template>
         <div id="container" class="container" tabindex$=[[tabindex]]>
-            <paper-ripple></paper-ripple>
             <div class="video">
+                <paper-ripple></paper-ripple>
                 <video on-tap="_handleTap" muted="{{muted}}" width$="{{width}}" poster="{{poster}}" preload="{{preload}}" height$="{{height}}" id="paperVideo" src="{{src}}" autoplay="{{autoplay}}" loop="{{loop}}"></video>
             </div>
             <paper-material elevation="1" hidden$="{{!controls}}" id="videoControls">


### PR DESCRIPTION
It doesn't feel right to have the ripple on the video get triggered when using the controls.
With this simple fix, I reorganised the elements so that the ripple effect is constrained solely to taps occurring in the actual video.

Also fixed the markdown syntax for the titles in the README file.